### PR TITLE
Fix container name consistency between ECS task definition and service

### DIFF
--- a/.github/workflows/ci-cd.yml
+++ b/.github/workflows/ci-cd.yml
@@ -11,7 +11,7 @@ env:
   ECR_REPOSITORY: mcp-dev-mcp-server
   ECS_SERVICE: mcp-dev-service
   ECS_CLUSTER: mcp-dev-cluster
-  CONTAINER_NAME: mcp-dev-mcp-server
+  CONTAINER_NAME: mcp-server
 
 jobs:
   test:

--- a/modules/ecs/main.tf
+++ b/modules/ecs/main.tf
@@ -23,7 +23,7 @@ resource "aws_ecs_task_definition" "mcp_task" {
 
   container_definitions = jsonencode([
     {
-      name      = "mcp-dev-mcp-server"
+      name      = "mcp-server"
       image     = var.container_image
       essential = true
       portMappings = [
@@ -75,7 +75,7 @@ resource "aws_ecs_service" "mcp_service" {
 
   load_balancer {
     target_group_arn = aws_lb_target_group.mcp_tg.arn
-    container_name   = "mcp-dev-mcp-server"
+    container_name   = "mcp-server"
     container_port   = var.container_port
   }
 


### PR DESCRIPTION
- Updated container name in ECS task definition to 'mcp-server'
- Updated container name in ECS service load balancer configuration
- Updated GitHub Actions workflow to use 'mcp-server' as container name